### PR TITLE
parse url to set parameters and return parameters as dict

### DIFF
--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -109,7 +109,6 @@ class IIIFImageClient(object):
         img.image_options['format'] = image_format
         return img
 
-
     @classmethod
     def init_from_url(ic, url):
         '''Init ImageClient using Image API parameters from URI.  Detect image vs. info request.
@@ -154,9 +153,10 @@ class IIIFImageClient(object):
     def dict_opts(self):
         
         '''
-        Aggregate method that fires other client methods that parse image request parameters.  Return a dictionary
-        with all image request parameters parsed to their most granular level.  Can be helpful for acting
-        logically on particular request parameters like heigh, width, mirroring, etc.
+        Aggregate method that fires other client methods that parse image request parameters.
+        Return a dictionary with all image request parameters parsed to their most granular level.
+        Can be helpful for acting logically on particular request parameters like height,
+        width, mirroring, etc.
         '''
 
         return {

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -3,7 +3,7 @@
 class InitURLError(Exception):
     def __init__(self,*args,**kwargs):
         Exception.__init__(self,*args,**kwargs)
-        
+
 
 class IIIFImageClient(object):
     '''Simple IIIF Image API client for generating IIIF image urls
@@ -231,7 +231,7 @@ class IIIFImageClient(object):
 
         # percent?
         if "pct" in size:
-            size_dict['pct'] = int(size.split(":")[1])
+            size_dict['pct'] = float(size.split(":")[1])
             return size_dict
 
         # exact?

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -1,5 +1,10 @@
 # iiifclient
 
+class InitURLError(Exception):
+    def __init__(self,*args,**kwargs):
+        Exception.__init__(self,*args,**kwargs)
+        
+
 class IIIFImageClient(object):
     '''Simple IIIF Image API client for generating IIIF image urls
     in an object-oriented, pythonic fashion.  Can be extended,
@@ -122,7 +127,7 @@ class IIIFImageClient(object):
             url_components = url.split('/')
 
             if len(url_components) < 5:
-                raise Exception('Not enough IIIF image parameters provided for information request {scheme}://{server}{/prefix}/{identifier}/info.json: %s' % url)
+                raise InitURLError('Not enough IIIF image parameters provided for information request {scheme}://{server}{/prefix}/{identifier}/info.json: %s' % url)
 
             _image_id = url_components[-2]
             _api_endpoint = '/'.join(url_components[:-3])
@@ -137,7 +142,7 @@ class IIIFImageClient(object):
 
             # check for enough IIIF parameters
             if len(url_components) < 8:
-                raise Exception('Not enough IIIF image parameters provided for image request {scheme}://{server}{/prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}: %s' % url)
+                raise InitURLError('Not enough IIIF image parameters provided for image request {scheme}://{server}{/prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}: %s' % url)
             
             _quality, _format = url_components[-1].split('.')
             _rotation = url_components[-2]
@@ -171,7 +176,7 @@ class IIIFImageClient(object):
         '''Parses region parameter into dictionary'''
 
         # return dictionary
-        region_d = {
+        region_dict = {
         'full': False,
         'x': None,
         'y': None,
@@ -184,31 +189,31 @@ class IIIFImageClient(object):
 
         # full?
         if region == 'full':
-            region_d['full'] = True
+            region_dict['full'] = True
             # return immediately
-            return region_d
+            return region_dict
 
         # percent?
         if "pct" in region:
-            region_d['pct'] = True
+            region_dict['pct'] = True
             region = region.split("pct:")[1]
 
         # split to dictionary
         # if percentage type, cast to float
-        if region_d['pct']:
-            region_d['x'],region_d['y'],region_d['w'],region_d['h'] = [float(region_c) for region_c in region.split(",")]
+        if region_dict['pct']:
+            region_dict['x'],region_dict['y'],region_dict['w'],region_dict['h'] = [float(region_c) for region_c in region.split(",")]
         # else, force int
         else:
-            region_d['x'],region_d['y'],region_d['w'],region_d['h'] = [int(region_c) for region_c in region.split(",")]
+            region_dict['x'],region_dict['y'],region_dict['w'],region_dict['h'] = [int(region_c) for region_c in region.split(",")]
 
-        return region_d
+        return region_dict
 
     def size_as_dict(self):
 
         '''Parses size parameter into dictionary'''
 
         # return dictionary
-        size_d = {
+        size_dict = {
         'full': False,
         'w': None,
         'h': None,
@@ -220,34 +225,34 @@ class IIIFImageClient(object):
 
         # full?
         if size == 'full':
-            size_d['full'] = True
+            size_dict['full'] = True
             # return immediately
-            return size_d
+            return size_dict
 
         # percent?
         if "pct" in size:
-            size_d['pct'] = int(size.split(":")[1])
-            return size_d
+            size_dict['pct'] = int(size.split(":")[1])
+            return size_dict
 
         # exact?
         if size.startswith('!'):
-            size_d['exact'] = True
+            size_dict['exact'] = True
             size = size[1:]
 
         # split width and height
         w,h = size.split(",")
         if w != '':
-            size_d['w'] = int(w)
+            size_dict['w'] = int(w)
         if h != '':
-            size_d['h'] = int(h) 
+            size_dict['h'] = int(h) 
 
-        return size_d
+        return size_dict
 
     def rotation_as_dict(self):
 
         '''Parses rotation parameter into dictionary'''
 
-        rotation_d = {
+        rotation_dict = {
         'degrees': None,
         'mirrored': False
         }
@@ -255,10 +260,10 @@ class IIIFImageClient(object):
         rotation = self.image_options['rotation']
 
         if rotation.startswith('!'):
-            rotation_d['mirrored'] = True
+            rotation_dict['mirrored'] = True
             rotation = rotation[1:]
 
         # rotation allows float
-        rotation_d['degrees'] = float(rotation)
+        rotation_dict['degrees'] = float(rotation)
 
-        return rotation_d
+        return rotation_dict

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -108,3 +108,125 @@ class IIIFImageClient(object):
         img = self.get_copy()
         img.image_options['format'] = image_format
         return img
+
+    def parse_from_url(self, url):
+        '''Parses Image API parameters from URL provided
+        Per http://iiif.io/api/image/2.0/#image-request-uri-syntax, using slashes to navigate URL'''
+        
+        url_components = url.split('/')
+        
+        _quality, _format = url_components[-1].split('.')
+        _rotation = url_components[-2]
+        _size = url_components[-3]
+        _region = url_components[-4]
+        _image_id = url_components[-5]
+        _api_endpoint = '/'.join(url_components[:-6])
+        
+        # reinit
+        self.__init__(api_endpoint=_api_endpoint, image_id=_image_id, region=_region,
+                     size=_size, rotation=_rotation, quality=_quality, format=_format)
+                     
+    def api_params_as_dict(self):
+        
+        '''
+        Returns dictionary of region, size, and rotation parameter strings
+        parsed as dictionaries.
+        '''
+
+        return {
+            'region':self._region_as_dict(),
+            'size':self._size_as_dict(),
+            'rotation':self._rotation_as_dict()            
+        }
+
+    # methods to derive python dictionaries from IIIF strings
+    def _region_as_dict(self):
+
+        '''Return dictionary of parsed region request'''
+
+        # return dictionary
+        region_d = {
+        'full': False,
+        'x': None,
+        'y': None,
+        'w': None,
+        'h': None,
+        'pct': False
+        }
+
+        region = self.image_options['region']
+
+        # full?
+        if region == 'full':
+            region_d['full'] = True
+            # return immediately
+            return region_d
+
+        # percent?
+        if "pct" in region:
+            region_d['pct'] = True
+            region = region.split("pct:")[1]
+
+        # split to dictionary
+        region_d['x'],region_d['y'],region_d['w'],region_d['h'] = region.split(",")
+
+        return region_d
+
+    def _size_as_dict(self):
+
+        '''Return dictionary of parsed size request'''
+
+        # return dictionary
+        size_d = {
+        'full': False,
+        'w': None,
+        'h': None,
+        'exact': False,
+        'pct': False,
+        }
+
+        size = self.image_options['size']
+
+        # full?
+        if size == 'full':
+            size_d['full'] = True
+            # return immediately
+            return size_d
+
+        # percent?
+        if "pct" in size:
+            size_d['pct'] = int(size.split(":")[1])
+            return size_d
+
+        # exact?
+        if size.startswith('!'):
+            size_d['exact'] = True
+            size = size[1:]
+
+        # split width and height
+        w,h = size.split(",")
+        if w != '':
+            size_d['w'] = int(w)
+        if h != '':
+            size_d['h'] = int(h)
+
+        return size_d
+
+    def _rotation_as_dict(self):
+
+        '''Return dictionary of parsed rotation request'''
+
+        rotation_d = {
+        'degrees': None,
+        'mirrored': False
+        }
+
+        rotation = self.image_options['rotation']
+
+        if rotation.startswith('!'):
+            rotation_d['mirrored'] = True
+            rotation = rotation[1:]
+
+        rotation_d['degrees'] = int(rotation)
+
+        return rotation_d

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -109,40 +109,66 @@ class IIIFImageClient(object):
         img.image_options['format'] = image_format
         return img
 
-    def init_from_url(self, url):
-        '''Parses Image API parameters from URL provided
-        Per http://iiif.io/api/image/2.0/#image-request-uri-syntax, using slashes to navigate URL'''
+
+    @classmethod
+    def init_from_url(ic, url):
+        '''Init ImageClient using Image API parameters from URI.  Detect image vs. info request.
+        Can count reliably from the end of the URI backwards, but cannot assume how many slashes 
+        make up the api_endpoint.  Returns new instance of IIIFImageClient.
+        Per http://iiif.io/api/image/2.0/#image-request-uri-syntax, using slashes to parse URI'''
         
-        url_components = url.split('/')
-        
-        _quality, _format = url_components[-1].split('.')
-        _rotation = url_components[-2]
-        _size = url_components[-3]
-        _region = url_components[-4]
-        _image_id = url_components[-5]
-        _api_endpoint = '/'.join(url_components[:-6])
-        
-        # reinit
-        self.__init__(api_endpoint=_api_endpoint, image_id=_image_id, region=_region,
-                     size=_size, rotation=_rotation, quality=_quality, format=_format)
+        # info request
+        if url.endswith('info.json'):
+
+            url_components = url.split('/')
+
+            if len(url_components) < 5:
+                raise Exception('Not enough IIIF image parameters provided for information request {scheme}://{server}{/prefix}/{identifier}/info.json: %s' % url)
+
+            _image_id = url_components[-2]
+            _api_endpoint = '/'.join(url_components[:-3])
+
+            # reinit
+            return ic(api_endpoint=_api_endpoint, image_id=_image_id)
+
+        # image request
+        else:
+
+            url_components = url.split('/')
+
+            # check for enough IIIF parameters
+            if len(url_components) < 8:
+                raise Exception('Not enough IIIF image parameters provided for image request {scheme}://{server}{/prefix}/{identifier}/{region}/{size}/{rotation}/{quality}.{format}: %s' % url)
+            
+            _quality, _format = url_components[-1].split('.')
+            _rotation = url_components[-2]
+            _size = url_components[-3]
+            _region = url_components[-4]
+            _image_id = url_components[-5]
+            _api_endpoint = '/'.join(url_components[:-6])
+            
+            # reinit
+            return ic(api_endpoint=_api_endpoint, image_id=_image_id, region=_region,
+                         size=_size, rotation=_rotation, quality=_quality, format=_format)
                      
-    def api_params_as_dict(self):
+    def dict_opts(self):
         
         '''
-        Returns dictionary of region, size, and rotation parameter strings
-        parsed as dictionaries.
+        Aggregate method that fires other client methods that parse image request parameters.  Return a dictionary
+        with all image request parameters parsed to their most granular level.  Can be helpful for acting
+        logically on particular request parameters like heigh, width, mirroring, etc.
         '''
 
         return {
-            'region':self._region_as_dict(),
-            'size':self._size_as_dict(),
-            'rotation':self._rotation_as_dict()            
+            'region':self.region_as_dict(),
+            'size':self.size_as_dict(),
+            'rotation':self.rotation_as_dict()            
         }
 
     # methods to derive python dictionaries from IIIF strings
-    def _region_as_dict(self):
+    def region_as_dict(self):
 
-        '''Return dictionary of parsed region request'''
+        '''Parses region parameter into dictionary'''
 
         # return dictionary
         region_d = {
@@ -168,13 +194,18 @@ class IIIFImageClient(object):
             region = region.split("pct:")[1]
 
         # split to dictionary
-        region_d['x'],region_d['y'],region_d['w'],region_d['h'] = region.split(",")
+        # if percentage type, cast to float
+        if region_d['pct']:
+            region_d['x'],region_d['y'],region_d['w'],region_d['h'] = [float(region_c) for region_c in region.split(",")]
+        # else, force int
+        else:
+            region_d['x'],region_d['y'],region_d['w'],region_d['h'] = [int(region_c) for region_c in region.split(",")]
 
         return region_d
 
-    def _size_as_dict(self):
+    def size_as_dict(self):
 
-        '''Return dictionary of parsed size request'''
+        '''Parses size parameter into dictionary'''
 
         # return dictionary
         size_d = {
@@ -208,13 +239,13 @@ class IIIFImageClient(object):
         if w != '':
             size_d['w'] = int(w)
         if h != '':
-            size_d['h'] = int(h)
+            size_d['h'] = int(h) 
 
         return size_d
 
-    def _rotation_as_dict(self):
+    def rotation_as_dict(self):
 
-        '''Return dictionary of parsed rotation request'''
+        '''Parses rotation parameter into dictionary'''
 
         rotation_d = {
         'degrees': None,
@@ -227,6 +258,7 @@ class IIIFImageClient(object):
             rotation_d['mirrored'] = True
             rotation = rotation[1:]
 
-        rotation_d['degrees'] = int(rotation)
+        # rotation allows float
+        rotation_d['degrees'] = float(rotation)
 
         return rotation_d

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -109,7 +109,7 @@ class IIIFImageClient(object):
         img.image_options['format'] = image_format
         return img
 
-    def parse_from_url(self, url):
+    def init_from_url(self, url):
         '''Parses Image API parameters from URL provided
         Per http://iiif.io/api/image/2.0/#image-request-uri-syntax, using slashes to navigate URL'''
         

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -4,6 +4,15 @@ import pytest
 api_endpoint = 'http://imgserver.co/'
 image_id = 'img1'
 
+# initialize from URI examples
+good_test_info_url = 'http://imgserver.co/loris/img1/info.json'
+good_test_image_url_simple = 'http://imgserver.co/loris/img1/full/full/0/default.jpg'
+good_test_image_url_complex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
+
+malformed_test_info_url = 'http://img1/info.json'
+malformed_test_image_url_simple = 'http://imgserver.co/loris/img1/foobar/default.jpg'
+malformed_test_image_url_copmlex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
+
 
 def get_test_imgclient():
     return iiif.IIIFImageClient(api_endpoint=api_endpoint,
@@ -56,25 +65,48 @@ class TestIIIFImageClient:
         with pytest.raises(Exception):
             img.format('bogus')
 
-    # initialize from URI examples
-    good_test_info_url = 'http://imgserver.co/loris/img1/info.json'
-    good_test_image_url_simple = 'http://imgserver.co/loris/img1/full/full/0/default.jpg'
-    good_test_image_url_copmlex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
     
-    bad_test_info_url = 'http://img1/info.json'
-    bad_test_image_url_simple = 'http://imgserver.co/loris/img1/foobar/default.jpg'
-    bad_test_image_url_copmlex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
 
     def test_init_from_url(self):
-
         # well-formed
         img = iiif.IIIFImageClient.init_from_url(good_test_info_url)
+        assert type(img) == iiif.IIIFImageClient
         img = iiif.IIIFImageClient.init_from_url(good_test_image_url_simple)
-        img = iiif.IIIFImageClient.init_from_url(good_test_image_url_copmlex)
-
+        assert type(img) == iiif.IIIFImageClient
+        img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
+        assert type(img) == iiif.IIIFImageClient
         # malformed
-        img = iiif.IIIFImageClient.init_from_url(malformed_test_info_url)
-        img = iiif.IIIFImageClient.init_from_url(malformed_test_image_url_simple)
-        img = iiif.IIIFImageClient.init_from_url(malformed_test_image_url_copmlex)
+        with pytest.raises(Exception):
+            img = iiif.IIIFImageClient.init_from_url(malformed_test_info_url)
+            img = iiif.IIIFImageClient.init_from_url(malformed_test_image_url_simple)
+            img = iiif.IIIFImageClient.init_from_url(malformed_test_image_url_copmlex)
+
+
+    def test_region_as_dict(self):
+        img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
+        assert img.region_as_dict() == {'full': False, 'h': 256, 'pct': False, 'w': 256, 'x': 2560, 'y': 2560}
+
+
+    def test_size_as_dict(self):
+        img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
+        assert img.size_as_dict() == {'exact': False, 'full': False, 'h': None, 'pct': False, 'w': 256}
+
+
+    def test_rotation_as_dict(self):
+        img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
+        assert img.rotation_as_dict() == {'degrees': 90.0, 'mirrored': True}
+
+
+    def test_dict_opts(self):
+        img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
+        assert img.dict_opts() == {'region': {'full': False,
+        'h': 256,
+        'pct': False,
+        'w': 256,
+        'x': 2560,
+        'y': 2560},
+        'rotation': {'degrees': 90.0, 'mirrored': True},
+        'size': {'exact': False, 'full': False, 'h': None, 'pct': False, 'w': 256}}
+
 
 

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -4,7 +4,7 @@ import pytest
 api_endpoint = 'http://imgserver.co/'
 image_id = 'img1'
 
-# initialize from URI examples
+# test urls
 good_test_info_url = 'http://imgserver.co/loris/img1/info.json'
 good_test_image_url_simple = 'http://imgserver.co/loris/img1/full/full/0/default.jpg'
 good_test_image_url_complex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
@@ -65,8 +65,6 @@ class TestIIIFImageClient:
         with pytest.raises(Exception):
             img.format('bogus')
 
-    
-
     def test_init_from_url(self):
         # well-formed
         img = iiif.IIIFImageClient.init_from_url(good_test_info_url)
@@ -76,37 +74,46 @@ class TestIIIFImageClient:
         img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
         assert type(img) == iiif.IIIFImageClient
         # malformed
-        with pytest.raises(Exception):
+        with pytest.raises(iiif.InitURLError):
             img = iiif.IIIFImageClient.init_from_url(malformed_test_info_url)
             img = iiif.IIIFImageClient.init_from_url(malformed_test_image_url_simple)
             img = iiif.IIIFImageClient.init_from_url(malformed_test_image_url_copmlex)
-
 
     def test_region_as_dict(self):
         img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
         assert img.region_as_dict() == {'full': False, 'h': 256, 'pct': False, 'w': 256, 'x': 2560, 'y': 2560}
 
-
     def test_size_as_dict(self):
         img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
         assert img.size_as_dict() == {'exact': False, 'full': False, 'h': None, 'pct': False, 'w': 256}
-
 
     def test_rotation_as_dict(self):
         img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
         assert img.rotation_as_dict() == {'degrees': 90.0, 'mirrored': True}
 
-
     def test_dict_opts(self):
         img = iiif.IIIFImageClient.init_from_url(good_test_image_url_complex)
-        assert img.dict_opts() == {'region': {'full': False,
-        'h': 256,
-        'pct': False,
-        'w': 256,
-        'x': 2560,
-        'y': 2560},
-        'rotation': {'degrees': 90.0, 'mirrored': True},
-        'size': {'exact': False, 'full': False, 'h': None, 'pct': False, 'w': 256}}
+        assert img.dict_opts() == {
+            'region': {
+                'full': False,
+                'h': 256,
+                'pct': False,
+                'w': 256,
+                'x': 2560,
+                'y': 2560
+            },
+            'rotation': {
+                'degrees': 90.0,
+                'mirrored': True
+            },
+            'size': {
+                'exact': False,
+                'full': False,
+                'h': None,
+                'pct': False,
+                'w': 256
+            }
+        }
 
 
 

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -56,3 +56,13 @@ class TestIIIFImageClient:
         with pytest.raises(Exception):
             img.format('bogus')
 
+    def test_url_parse(self):
+        img = iiif.IIIFImageClient()
+        # simple API parameters
+        img.parse_from_url('http://imgserver.co/loris/img1/full/full/0/default.jpg')
+        img.api_params_as_dict()
+        # more complex API parameters
+        img.parse_from_url('http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg')
+        img.api_params_as_dict()
+
+

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -60,22 +60,21 @@ class TestIIIFImageClient:
     good_test_info_url = 'http://imgserver.co/loris/img1/info.json'
     good_test_image_url_simple = 'http://imgserver.co/loris/img1/full/full/0/default.jpg'
     good_test_image_url_copmlex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
+    
     bad_test_info_url = 'http://img1/info.json'
     bad_test_image_url_simple = 'http://imgserver.co/loris/img1/foobar/default.jpg'
     bad_test_image_url_copmlex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
 
     def test_init_from_url(self):
 
-        img = iiif.IIIFImageClient()
-
         # well-formed
-        img.init_from_url(good_test_info_url)
-        img.init_from_url(good_test_image_url_simple)
-        img.init_from_url(good_test_image_url_copmlex)
+        img = iiif.IIIFImageClient.init_from_url(good_test_info_url)
+        img = iiif.IIIFImageClient.init_from_url(good_test_image_url_simple)
+        img = iiif.IIIFImageClient.init_from_url(good_test_image_url_copmlex)
 
         # malformed
-        img.init_from_url(malformed_test_info_url)
-        img.init_from_url(malformed_test_image_url_simple)
-        img.init_from_url(malformed_test_image_url_copmlex)
+        img = iiif.IIIFImageClient.init_from_url(malformed_test_info_url)
+        img = iiif.IIIFImageClient.init_from_url(malformed_test_image_url_simple)
+        img = iiif.IIIFImageClient.init_from_url(malformed_test_image_url_copmlex)
 
 

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -56,13 +56,26 @@ class TestIIIFImageClient:
         with pytest.raises(Exception):
             img.format('bogus')
 
-    def test_url_parse(self):
+    # initialize from URI examples
+    good_test_info_url = 'http://imgserver.co/loris/img1/info.json'
+    good_test_image_url_simple = 'http://imgserver.co/loris/img1/full/full/0/default.jpg'
+    good_test_image_url_copmlex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
+    bad_test_info_url = 'http://img1/info.json'
+    bad_test_image_url_simple = 'http://imgserver.co/loris/img1/foobar/default.jpg'
+    bad_test_image_url_copmlex = 'http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg'
+
+    def test_init_from_url(self):
+
         img = iiif.IIIFImageClient()
-        # simple API parameters
-        img.parse_from_url('http://imgserver.co/loris/img1/full/full/0/default.jpg')
-        img.api_params_as_dict()
-        # more complex API parameters
-        img.parse_from_url('http://imgserver.co/loris/img1/2560,2560,256,256/256,/!90/default.jpg')
-        img.api_params_as_dict()
+
+        # well-formed
+        img.init_from_url(good_test_info_url)
+        img.init_from_url(good_test_image_url_simple)
+        img.init_from_url(good_test_image_url_copmlex)
+
+        # malformed
+        img.init_from_url(malformed_test_info_url)
+        img.init_from_url(malformed_test_image_url_simple)
+        img.init_from_url(malformed_test_image_url_copmlex)
 
 


### PR DESCRIPTION
Not sure at all if this is in scope for the IIIFImageClient, but thought it was worth throwing out there.

Would be two additions: 
* ability to provide and parse a URL to set the `api_endpoint`, `image_id`, `region`, `size`, `rotation`, `quality`, and `format` of the client instance
* return a dictionary that parses the more complex parameters of `region`, `size`, and `rotation` 

We have a use case where we want to determine the height and/or width that a URL is requesting, and whether or not it's mirrored.  These two additions make that pretty easy given a URL.

e.g.
```
from piffle.iiif import IIIFImageClient
ic = IIIFImageClient()

ic.parse_from_url('http://localhost/loris/foo:bar/full/full/0/default.jpg')
In [5]: ic.api_params_as_dict()
Out[5]: 
{'region': {'full': True,
  'h': None,
  'pct': False,
  'w': None,
  'x': None,
  'y': None},
 'rotation': {'degrees': 0, 'mirrored': False},
 'size': {'exact': False, 'full': True, 'h': None, 'pct': False, 'w': None}}

# with more parameters
ic.parse_from_url('http://localhost/loris/foo:bar/2560,2560,256,256/256,/!90/default.jpg')
In [11]: ic.api_params_as_dict()
Out[11]: 
{'region': {'full': False,
  'h': '256',
  'pct': False,
  'w': '256',
  'x': '2560',
  'y': '2560'},
 'rotation': {'degrees': 90, 'mirrored': True},
 'size': {'exact': False, 'full': False, 'h': None, 'pct': False, 'w': 256}}
```

Either way, thanks for breaking this into it's own package!  Mighty handy.