### PR TITLE
cast rotation as string for mirror checking in ImageRotation

### DIFF
--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -349,7 +349,7 @@ class ImageRotation(object):
         # reset to defaults before parsing
         self.options = self.rotation_defaults.copy()
 
-        if rotation.startswith('!'):
+        if str(rotation).startswith('!'):
             self.options['mirrored'] = True
             rotation = rotation.lstrip('!')
 


### PR DESCRIPTION
For a pythonic client to IIIF, wondered if makes sense to allow integers for the integer-based `rotation` parameter?

Passing an integer currently snags [here](https://github.com/emory-lits-labs/piffle/blob/develop/piffle/iiif.py#L352) where it checks for `!` with `.startswith()`.  Casting the rotation there as a string allows for this check to continue, and strip the `!` if it exists.

You could convert to string right away when the ImageRotation inits [here](https://github.com/emory-lits-labs/piffle/blob/develop/piffle/iiif.py#L316-L320), but seems like it may be nice to keep that an integer in the event that is helpful down the road?

Just a thought.
