### PR TITLE
Add python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 install:
   - pip install -e .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change & Version Information
 
+## 0.3
+
+* Now Python 3 compatible
+
 ## 0.2.1
 
 * Bug fix: chaining multiple different options combines all of them properly and does not modify

--- a/piffle/iiif.py
+++ b/piffle/iiif.py
@@ -1,7 +1,9 @@
 # iiifclient
 
 from collections import OrderedDict
-from urlparse import urlparse
+from future.utils import python_2_unicode_compatible
+import six
+from six.moves.urllib.parse import urlparse
 
 
 class IIIFImageClientException(Exception):
@@ -20,6 +22,7 @@ class ParseError(IIIFImageClientException):
 # validating options (and could add option type checking)
 
 
+@python_2_unicode_compatible
 class ImageRegion(object):
     '''IIIF Image region. Intended to be used with :class:`IIIFImageClient`.
     Can be initialized with related image object and region options.
@@ -74,7 +77,7 @@ class ImageRegion(object):
 
     def set_options(self, **options):
         '''Update region options.  Same parameters as initialiation.'''
-        allowed_options = self.options.keys()
+        allowed_options = list(self.options.keys())
         # error if an unrecoganized option is specified
         for key in options:
             if key not in allowed_options:
@@ -102,7 +105,7 @@ class ImageRegion(object):
         '''Return region options as a dictionary'''
         return self.options
 
-    def __unicode__(self):
+    def __str__(self):
         '''Render region information in IIIF region format'''
         if self.options['full']:
             return 'full'
@@ -158,6 +161,7 @@ class ImageRegion(object):
         self.options.update({'x': x, 'y': y, 'width': width, 'height': height})
 
 
+@python_2_unicode_compatible
 class ImageSize(object):
     '''IIIF Image Size.  Intended to be used with :class:`IIIFImageClient`.
     Can be initialized with related image object and size options.
@@ -214,7 +218,7 @@ class ImageSize(object):
 
     def set_options(self, **options):
         '''Update size options.  Same parameters as initialiation.'''
-        allowed_options = self.options.keys()
+        allowed_options = list(self.options.keys())
         # error if an unrecoganized option is specified
         for key in options:
             if key not in allowed_options:
@@ -234,7 +238,7 @@ class ImageSize(object):
         '''Return size options as a dictionary'''
         return self.options
 
-    def __unicode__(self):
+    def __str__(self):
         if self.options['full']:
             return 'full'
         if self.options['max']:
@@ -289,6 +293,7 @@ class ImageSize(object):
             raise ParseError('Error parsing size: %s' % size)
 
 
+@python_2_unicode_compatible
 class ImageRotation(object):
     '''IIIF Image rotation Intended to be used with :class:`IIIFImageClient`.
     Can be initialized with related image object and rotation options.
@@ -341,7 +346,7 @@ class ImageRotation(object):
         '''Return rotation options as a dictionary'''
         return self.options
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s%g' % ('!' if self.options['mirrored'] else '',
                          self.options['degrees'])
 
@@ -357,6 +362,7 @@ class ImageRotation(object):
         self.options['degrees'] = float(rotation)
 
 
+@python_2_unicode_compatible
 class IIIFImageClient(object):
     '''Simple IIIF Image API client for generating IIIF image urls
     in an object-oriented, pythonic fashion.  Can be extended,
@@ -421,19 +427,16 @@ class IIIFImageClient(object):
         'Image id to be used in contructing urls'
         return self.image_id
 
-    def __unicode__(self):
+    def __str__(self):
         info = self.image_options.copy()
         info.update({
             'endpoint': self.api_endpoint,
             'id': self.get_image_id(),
-            'region': unicode(self.region),
-            'size': unicode(self.size),
-            'rot': unicode(self.rotation)
+            'region': six.text_type(self.region),
+            'size': six.text_type(self.size),
+            'rot': six.text_type(self.rotation)
         })
         return '%(endpoint)s/%(id)s/%(region)s/%(size)s/%(rot)s/%(quality)s.%(fmt)s' % info
-
-    def __str__(self):
-        return str(unicode(self))
 
     def __repr__(self):
         return '<IIIFImageClient %s>' % self.get_image_id()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     url='https://github.com/emory-lits-labs/piffle',
     license='Apache License, Version 2.0',
     packages=find_packages(),
-    install_requires=[],
+    install_requires=['six', 'future'],
     setup_requires=['pytest-runner'],
     tests_require=test_requirements,
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,12 @@ CLASSIFIERS = [
     'Natural Language :: English',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
 

--- a/tests/test_piffle.py
+++ b/tests/test_piffle.py
@@ -1,4 +1,5 @@
 from piffle import iiif
+import six
 import pytest
 
 api_endpoint = 'http://imgserver.co'
@@ -34,15 +35,15 @@ class TestIIIFImageClient:
         img = get_test_imgclient()
         # default image url
         assert '%s/%s/full/full/0/default.jpg' % (api_endpoint, image_id) \
-               == unicode(img)
+               == six.text_type(img)
         # info url
         assert '%s/%s/info.json' % (api_endpoint, image_id) \
-               == unicode(img.info())
+               == six.text_type(img.info())
 
     def test_outputs(self):
         img = get_test_imgclient()
         # str and unicode should be equivalent
-        assert unicode(img.info()) == unicode(str(img.info()))
+        assert six.text_type(img.info()) == six.text_type(str(img.info()))
         # repr should have class and image id
         assert 'IIIFImageClient' in repr(img)
         assert img.get_image_id() in repr(img)
@@ -59,9 +60,9 @@ class TestIIIFImageClient:
         del expected_img_opts['size']
         del expected_img_opts['rotation']
         assert img.image_options == expected_img_opts
-        assert unicode(img.region) == test_opts['region']
-        assert unicode(img.size) == test_opts['size']
-        assert unicode(img.rotation) == test_opts['rotation']
+        assert six.text_type(img.region) == test_opts['region']
+        assert six.text_type(img.size) == test_opts['size']
+        assert six.text_type(img.rotation) == test_opts['rotation']
 
         # TODO: should parse/verify options on init
         # with pytest.raises(iiif.IIIFImageClientException):
@@ -72,24 +73,24 @@ class TestIIIFImageClient:
         width, height, percent = 100, 150, 50
         # width only
         assert '%s/%s/full/%s,/0/default.jpg' % (api_endpoint, image_id, width)\
-            == unicode(img.size(width=width))
+            == six.text_type(img.size(width=width))
 
         # height only
         assert '%s/%s/full/,%s/0/default.jpg' % \
                (api_endpoint, image_id, height) == \
-               unicode(img.size(height=height))
+               six.text_type(img.size(height=height))
         # width and height
         assert '%s/%s/full/%s,%s/0/default.jpg' % \
                (api_endpoint, image_id, width, height) == \
-               unicode(img.size(width=width, height=height))
+               six.text_type(img.size(width=width, height=height))
         # exact width and height
         assert '%s/%s/full/!%s,%s/0/default.jpg' % \
                (api_endpoint, image_id, width, height) == \
-               unicode(img.size(width=width, height=height, exact=True))
+               six.text_type(img.size(width=width, height=height, exact=True))
         # percent
         assert '%s/%s/full/pct:%s/0/default.jpg' % \
                (api_endpoint, image_id, percent) == \
-               unicode(img.size(percent=percent))
+               six.text_type(img.size(percent=percent))
 
     def test_region(self):
         # region options passed through to region object and output
@@ -97,14 +98,14 @@ class TestIIIFImageClient:
         x, y, width, height = 5, 10, 100, 150
         assert '%s/%s/%s,%s,%s,%s/full/0/default.jpg' % \
                (api_endpoint, image_id, x, y, width, height) \
-            == unicode(img.region(x=x, y=y, width=width, height=height))
+            == six.text_type(img.region(x=x, y=y, width=width, height=height))
 
     def test_rotation(self):
         # rotation options passed through to region object and output
         img = get_test_imgclient()
         assert '%s/%s/full/full/90/default.jpg' % \
                (api_endpoint, image_id) \
-            == unicode(img.rotation(degrees=90))
+            == six.text_type(img.rotation(degrees=90))
         with pytest.raises(iiif.IIIFImageClientException):
             img.rotation(foo='bar')
 
@@ -113,9 +114,9 @@ class TestIIIFImageClient:
         png = img.format('png')
         jpg = img.format('jpg')
         gif = img.format('gif')
-        assert unicode(png).endswith('.png')
-        assert unicode(jpg).endswith('.jpg')
-        assert unicode(gif).endswith('.gif')
+        assert six.text_type(png).endswith('.png')
+        assert six.text_type(jpg).endswith('.jpg')
+        assert six.text_type(gif).endswith('.gif')
 
         with pytest.raises(iiif.IIIFImageClientException):
             img.format('bogus')
@@ -126,31 +127,31 @@ class TestIIIFImageClient:
         fmt = 'png'
         assert '%s/%s/full/%s,/0/default.%s' % \
                (api_endpoint, image_id, width, fmt)\
-            == unicode(img.size(width=width).format(fmt))
+            == six.text_type(img.size(width=width).format(fmt))
 
         img = get_test_imgclient()
         x, y, width, height = 5, 10, 100, 150
         assert '%s/%s/%s,%s,%s,%s/full/0/default.%s' % \
                (api_endpoint, image_id, x, y, width, height, fmt) \
-            == unicode(img.region(x=x, y=y,
+            == six.text_type(img.region(x=x, y=y,
                                   width=width, height=height).format(fmt))
 
         assert '%s/%s/%s,%s,%s,%s/%s,/0/default.%s' % \
                (api_endpoint, image_id, x, y, width, height, width, fmt) \
-            == unicode(img.size(width=width)
+            == six.text_type(img.size(width=width)
                           .region(x=x, y=y, width=width, height=height)
                           .format(fmt))
         rotation = 90
         assert '%s/%s/%s,%s,%s,%s/%s,/%s/default.%s' % \
                (api_endpoint, image_id, x, y, width, height, width, rotation, fmt) \
-            == unicode(img.size(width=width)
+            == six.text_type(img.size(width=width)
                           .region(x=x, y=y, width=width, height=height)
                           .rotation(degrees=90)
                           .format(fmt))
 
         # original image object should be unchanged, and still show defaults
         assert '%s/%s/full/full/0/default.jpg' % (api_endpoint, image_id) \
-               == unicode(img)
+               == six.text_type(img)
 
     def test_init_from_url(self):
         # well-formed
@@ -159,7 +160,7 @@ class TestIIIFImageClient:
         assert isinstance(img, iiif.IIIFImageClient)
         assert img.image_id == image_id
         # round trip back to original url
-        assert unicode(img.info()) == VALID_URLS['info']
+        assert six.text_type(img.info()) == VALID_URLS['info']
         assert img.api_endpoint == api_endpoint
         # -info with more complex endpoint base url
         img = iiif.IIIFImageClient.init_from_url(VALID_URLS['info-loris'])
@@ -167,12 +168,12 @@ class TestIIIFImageClient:
         # - image
         img = iiif.IIIFImageClient.init_from_url(VALID_URLS['simple'])
         assert isinstance(img, iiif.IIIFImageClient)
-        assert unicode(img) == VALID_URLS['simple']
+        assert six.text_type(img) == VALID_URLS['simple']
         img = iiif.IIIFImageClient.init_from_url(VALID_URLS['complex'])
-        assert unicode(img) == VALID_URLS['complex']
+        assert six.text_type(img) == VALID_URLS['complex']
         assert isinstance(img, iiif.IIIFImageClient)
         img = iiif.IIIFImageClient.init_from_url(VALID_URLS['exact'])
-        assert unicode(img) == VALID_URLS['exact']
+        assert six.text_type(img) == VALID_URLS['exact']
         assert isinstance(img, iiif.IIIFImageClient)
         assert img.size.options['exact'] is True
 
@@ -217,7 +218,7 @@ class TestImageRegion:
 
     def test_defaults(self):
         region = iiif.ImageRegion()
-        assert unicode(region) == 'full'
+        assert six.text_type(region) == 'full'
         assert region.as_dict() == iiif.ImageRegion.region_defaults
 
     def test_init(self):
@@ -261,36 +262,36 @@ class TestImageRegion:
 
     def test_render(self):
         region = iiif.ImageRegion(full=True)
-        assert unicode(region) == 'full'
+        assert six.text_type(region) == 'full'
         region = iiif.ImageRegion(square=True)
-        assert unicode(region) == 'square'
+        assert six.text_type(region) == 'square'
         region = iiif.ImageRegion(x=5, y=5, width=100, height=100)
-        assert unicode(region) == '5,5,100,100'
+        assert six.text_type(region) == '5,5,100,100'
         region = iiif.ImageRegion(x=5, y=5, width=100, height=100,
                                   percent=True)
-        assert unicode(region) == 'pct:5,5,100,100'
+        assert six.text_type(region) == 'pct:5,5,100,100'
         region = iiif.ImageRegion(x=5.1, y=3.14, width=100.76, height=100.89,
                                   percent=True)
-        assert unicode(region) == 'pct:5.1,3.14,100.76,100.89'
+        assert six.text_type(region) == 'pct:5.1,3.14,100.76,100.89'
 
     def test_parse(self):
         region = iiif.ImageRegion()
         # full
         region_str = 'full'
         region.parse(region_str)
-        assert unicode(region) == region_str  # round trip
+        assert six.text_type(region) == region_str  # round trip
         assert region.as_dict()['full'] is True
         # square
         region_str = 'square'
         region.parse(region_str)
-        assert unicode(region) == region_str  # round trip
+        assert six.text_type(region) == region_str  # round trip
         assert region.as_dict()['full'] is False
         assert region.as_dict()['square'] is True
         # region
         x, y, w, h = [5, 7, 100, 200]
         region_str = '%d,%d,%d,%d' % (x, y, w, h)
         region.parse(region_str)
-        assert unicode(region) == region_str  # round trip
+        assert six.text_type(region) == region_str  # round trip
         region_opts = region.as_dict()
         assert region_opts['full'] is False
         assert region_opts['square'] is False
@@ -301,7 +302,7 @@ class TestImageRegion:
         # percentage region
         region_str = 'pct:%d,%d,%d,%d' % (x, y, w, h)
         region.parse(region_str)
-        assert unicode(region) == region_str  # round trip
+        assert six.text_type(region) == region_str  # round trip
         region_opts = region.as_dict()
         assert region_opts['full'] is False
         assert region_opts['square'] is False
@@ -321,7 +322,7 @@ class TestImageSize:
 
     def test_defaults(self):
         size = iiif.ImageSize()
-        assert unicode(size) == 'full'
+        assert six.text_type(size) == 'full'
         assert size.as_dict() == iiif.ImageSize.size_defaults
 
     def test_init(self):
@@ -353,36 +354,36 @@ class TestImageSize:
 
     def test_render(self):
         size = iiif.ImageSize(full=True)
-        assert unicode(size) == 'full'
+        assert six.text_type(size) == 'full'
         size = iiif.ImageSize(max=True)
-        assert unicode(size) == 'max'
+        assert six.text_type(size) == 'max'
         size = iiif.ImageSize(percent=50)
-        assert unicode(size) == 'pct:50'
+        assert six.text_type(size) == 'pct:50'
         size = iiif.ImageSize(width=100, height=105)
-        assert unicode(size) == '100,105'
+        assert six.text_type(size) == '100,105'
         size = iiif.ImageSize(width=100)
-        assert unicode(size) == '100,'
+        assert six.text_type(size) == '100,'
         size = iiif.ImageSize(height=105)
-        assert unicode(size) == ',105'
+        assert six.text_type(size) == ',105'
 
     def test_parse(self):
         size = iiif.ImageSize()
         # full
         size_str = 'full'
         size.parse(size_str)
-        assert unicode(size) == size_str  # round trip
+        assert six.text_type(size) == size_str  # round trip
         assert size.as_dict()['full'] is True
         # max
         size_str = 'max'
         size.parse(size_str)
-        assert unicode(size) == size_str  # round trip
+        assert six.text_type(size) == size_str  # round trip
         assert size.as_dict()['full'] is False
         assert size.as_dict()['max'] is True
         # width and height
         w, h = [100, 200]
         size_str = '%d,%d' % (w, h)
         size.parse(size_str)
-        assert unicode(size) == size_str  # round trip
+        assert six.text_type(size) == size_str  # round trip
         size_opts = size.as_dict()
         assert size_opts['full'] is False
         assert size_opts['max'] is False
@@ -391,7 +392,7 @@ class TestImageSize:
         # percentage size
         size_str = 'pct:55'
         size.parse(size_str)
-        assert unicode(size) == size_str  # round trip
+        assert six.text_type(size) == size_str  # round trip
         size_opts = size.as_dict()
         assert size_opts['full'] is False
         assert size_opts['percent'] == 55
@@ -406,7 +407,7 @@ class TestImageRotation:
 
     def test_defaults(self):
         rotation = iiif.ImageRotation()
-        assert unicode(rotation) == '0'
+        assert six.text_type(rotation) == '0'
         assert rotation.as_dict() == iiif.ImageRotation.rotation_defaults
 
     def test_init(self):
@@ -420,18 +421,18 @@ class TestImageRotation:
 
     def test_render(self):
         rotation = iiif.ImageRotation()
-        assert unicode(rotation) == '0'
+        assert six.text_type(rotation) == '0'
         rotation = iiif.ImageRotation(degrees=90)
-        assert unicode(rotation) == '90'
+        assert six.text_type(rotation) == '90'
         rotation = iiif.ImageRotation(degrees=95, mirrored=True)
-        assert unicode(rotation) == '!95'
+        assert six.text_type(rotation) == '!95'
 
     def test_parse(self):
         rotation = iiif.ImageRotation()
         rotation_str = '180'
         rotation.parse(rotation_str)
-        assert unicode(rotation) == rotation_str  # round trip
+        assert six.text_type(rotation) == rotation_str  # round trip
         rotation_str = '!90'
         rotation.parse(rotation_str)
-        assert unicode(rotation) == rotation_str  # round trip
+        assert six.text_type(rotation) == rotation_str  # round trip
         assert rotation.as_dict()['mirrored'] is True


### PR DESCRIPTION
Minor updates so piffle can be used with either python 2 or 3.

Preserves python 2 support and adds a test matrix to travis-ci so multiple versions of python are tested.